### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,10 +1,10 @@
 # Datatypes
 
-Modus  KEYWORD1
+Modus	KEYWORD1
 
 # Methods and Functions
 
-mode     KEYWORD2
-set      KEYWORD2
-state    KEYWORD2
-status   KEYWORD2
+mode	KEYWORD2
+set	KEYWORD2
+state	KEYWORD2
+status	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords